### PR TITLE
Carrier portal track performance improvements

### DIFF
--- a/assets/postgres/tracks_index.sql.j2
+++ b/assets/postgres/tracks_index.sql.j2
@@ -1,3 +1,3 @@
 -- Ensure we run vacuumming after deleting most of the rows in the table
-CLUSTER VERBOSE public.{{ table_name }} USING public.{{ table_name }}_vessel_id_timestamp
+CLUSTER VERBOSE public.{{ table_name }} USING public.{{ table_name }}_vessel_id_timestamp;
 VACUUM ANALYZE public.{{ table_name }};

--- a/assets/postgres/tracks_index.sql.j2
+++ b/assets/postgres/tracks_index.sql.j2
@@ -1,2 +1,3 @@
 -- Ensure we run vacuumming after deleting most of the rows in the table
+CLUSTER VERBOSE public.{{ table_name }} USING public.{{ table_name }}_vessel_id_timestamp
 VACUUM ANALYZE public.{{ table_name }};

--- a/scripts/aggregate_tracks
+++ b/scripts/aggregate_tracks
@@ -41,7 +41,6 @@ fi
 ################################################################################
 TABLE_DESC=(
   "* Pipeline: ${PIPELINE} ${PIPELINE_VERSION}"
-  "* Sources: ${MESSAGES_TABLE} ${SEGMENT_INFO_TABLE} ${SEGMENT_VESSEL_TABLE}"
   "* Command:"
   "$(basename $0)"
   "$@"
@@ -86,8 +85,6 @@ jinja2 vessel_tracks_query.j2.sql \
    -D end_yyyymmdd_nodash=$(yyyymmdd ${END_DATE}) \
    -D start_yyyymmdd=${START_DATE} \
    -D end_yyyymmdd=${END_DATE} \
-   -D segment_info=${SEGMENT_INFO_TABLE//:/.} \
-   -D segment_vessel=${SEGMENT_VESSEL_TABLE//:/.} \
    | bq --headless query \
     -n 0 \
     --nouse_legacy_sql \

--- a/scripts/aggregate_tracks
+++ b/scripts/aggregate_tracks
@@ -86,6 +86,8 @@ jinja2 vessel_tracks_query.j2.sql \
    -D end_yyyymmdd_nodash=$(yyyymmdd ${END_DATE}) \
    -D start_yyyymmdd=${START_DATE} \
    -D end_yyyymmdd=${END_DATE} \
+   -D segment_info=${SEGMENT_INFO_TABLE//:/.} \
+   -D segment_vessel=${SEGMENT_VESSEL_TABLE//:/.} \
    | bq --headless query \
     -n 0 \
     --nouse_legacy_sql \


### PR DESCRIPTION
This PR fixes improves the performance of track queries by adding physical clustering on the tracks table.

This also removes some deprecated messages we were echoing on stdout. We are no longer sending in the `segment_vessel` and `segment_info` tables now that the tracks aggregation query is parametrizable, so no need to have the source echo empty values there.